### PR TITLE
Allow to customize runUser and runGroup

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -39,18 +39,18 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false
-          runAsGroup: 2000
+          runAsGroup: {{ .Values.deployment.runAsGroup }}
           runAsNonRoot: true
-          runAsUser: 2000
+          runAsUser: {{ .Values.deployment.runAsUser }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsGroup: 2000
+        runAsGroup: {{ .Values.deployment.runAsGroup }}
         runAsNonRoot: true
-        runAsUser: 2000
+        runAsUser: {{ .Values.deployment.runAsUser }}
       serviceAccount: {{ .Chart.Name }}
       serviceAccountName: {{ .Chart.Name }}
       terminationGracePeriodSeconds: 30

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -6,3 +6,6 @@ podEnv:
     value: "3m"
   - name: GIT_PROVIDER_SERVICE_PORT_HACK
     value: "false"
+deployment:
+  runAsGroup: 2000
+  runAsUser: 2000


### PR DESCRIPTION
On some environments such as OpenShift the runAsUser and runAsGroup values might be strictly defined in a given range, which might not include the current default value 2000.

This patch allow to customize such values, while keeping value 2000 as the default.